### PR TITLE
fix asset output path

### DIFF
--- a/structure/assets.nix
+++ b/structure/assets.nix
@@ -15,7 +15,7 @@ in
   };
 
   config.content-types.asset =
-    { ... }:
+    { config, ... }:
     {
       imports = [ cfg.content-types.document ];
 


### PR DESCRIPTION
The path attribute is relative to the asset, not the global config.

### Before

```shellSession
nix-repl> (import ./example).config.assets."heebo-extended.woff2".outputs
error:
       … while evaluating the attribute 'value'
         at /nix/store/qfiliajkp5rxmhbi1bn4xxl7s2hp2n4y-source/lib/modules.nix:927:9:
          926|     in warnDeprecation opt //
          927|       { value = addErrorContext "while evaluating the option `${showOption loc}':" value;
             |         ^
          928|         inherit (res.defsFinal') highestPrio;

       … while evaluating the option `assets."heebo-extended.woff2".outputs':

       … while evaluating the attribute 'mergedValue'
         at /nix/store/qfiliajkp5rxmhbi1bn4xxl7s2hp2n4y-source/lib/modules.nix:962:5:
          961|     # Type-check the remaining definitions, and merge them. Or throw if no definitions.
          962|     mergedValue =
             |     ^
          963|       if isDefined then

       … while evaluating definitions from `/home/kuroko/Files/System/Downloads/Temporary/htmnix/structure/assets.nix, via option content-types.asset':

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: attribute 'path' missing
       at /home/kuroko/Files/System/Downloads/Temporary/htmnix/structure/assets.nix:27:46:
           26|       # XXX: the "" output type means raw files
           27|       config.outputs."" = if lib.isStorePath config.path then config.path else "${config.path}";
             |                                              ^
           28|     };
```

### After

```shellSession
nix-repl> (import ./example).config.assets."heebo-extended.woff2".outputs
{
  "" = «derivation /nix/store/l15fk2003g1zbx04abb2wz70dvzkb8wf-heebo-extended.woff2.drv»;
}
```